### PR TITLE
Mouse event patch

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,7 @@
 cp source/build/pdf.worker.js source/web/cmaps/ source/web/images/ source/web/locale/ . -a
 
 cat source/web/l10n.js source/build/pdf.js source/build/pdf.worker.js source/web/compatibility.js source/web/debugger.js source/web/viewer.js > pdf.js
+patch pdf.js < pdf.js.patch
 
 uglifycss source/web/viewer.css > viewer.css
 node grunt/css-prefix.js viewer.css viewer.css pdfjs

--- a/pdf.js
+++ b/pdf.js
@@ -57179,6 +57179,9 @@ window.addEventListener('pagechange', function pagechange(evt) {
 }, true);
 
 function handleMouseWheel(evt) {
+  // Ignore mousewheel event if pdfViewer isn't loaded
+  if (!PDFViewerApplication.pdfViewer) return;
+  
   var MOUSE_WHEEL_DELTA_FACTOR = 40;
   var ticks = (evt.type === 'DOMMouseScroll') ? -evt.detail :
               evt.wheelDelta / MOUSE_WHEEL_DELTA_FACTOR;


### PR DESCRIPTION
Don't trigger an error when pdfViewer isn't loaded.

    Uncaught TypeError: Cannot read property 'isInPresentationMode' of null