### PR TITLE
Upgrade instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,210 @@ Include `viewer.html` using [SSI](http://httpd.apache.org/docs/2.4/howto/ssi.htm
 </html>
 ```
 
+## Upgrading the source
+
+Normally mozilla's PDF js viewer, will only run as standalone. This version is patched so you can include it within a
+page.
+
+To update this version, get the pdf.js source code and build the project
+
+    git clone https://github.com/mozilla/pdf.js.git
+    cd pdf.js
+    npm install
+    node make generic
+    cd ..
+
+And update the files from source and patch them
+
+    cd pdf.js-viewer
+    npm install
+    ./build.sh ../pdf.js/build/generic/
+
+### Manual patching
+
+When updating to a new minor (or major) version, it's likely than one or more of the chunks can't be applied. This
+means you need to do these modifications manually.
+
+
+#### function getL10nData()
+
+The viewer uses `l10n.js` with a `<link rel="resource" type="application/l10n">` header for internationalization. This
+chunk makes using that optional.
+
+       function getL10nData(key, args, fallback) {
+         var data = gL10nData[key];
+         if (!data) {
+    -      console.warn('#' + key + ' is undefined.');
+    +      if (Object.keys(gL10nData).length > 0) {
+    +        console.warn('#' + key + ' is undefined.');
+    +      }
+           if (!fallback) {
+             return null;
+           }
+
+#### Dynamic paths
+
+The viewer uses relative paths to JavaScript files. This doesn't work when the viewer is embedded on a web page.
+Instead the paths are determined based on the path of the current JavaScript file.
+
+    -PDFJS.imageResourcesPath = './images/';
+    -  PDFJS.workerSrc = '../build/pdf.worker.js';
+    -  PDFJS.cMapUrl = '../web/cmaps/';
+    -  PDFJS.cMapPacked = true;
+    +var scriptTagContainer = document.body ||
+    +                         document.getElementsByTagName('head')[0];
+    +var pdfjsSrc = scriptTagContainer.lastChild.src;
+    +
+    +if (pdfjsSrc) {
+    +  PDFJS.imageResourcesPath = pdfjsSrc.replace(/pdf\.js$/i, 'images/');
+    +  PDFJS.workerSrc = pdfjsSrc.replace(/pdf\.js$/i, 'pdf.worker.js');
+    +  PDFJS.cMapUrl = pdfjsSrc.replace(/pdf\.js$/i, 'cmaps/');
+    +}
+    +
+    +PDFJS.cMapPacked = true;
+
+#### Explicitly load a PDF document
+
+The viewer shouldn't start loading a (default) document when it's loaded. Instead we want to expose the initialization,
+so it can be called in JavaScript with `PDFJS.webViewerLoad()`.
+
+    -document.addEventListener('DOMContentLoaded', webViewerLoad, true);
+    +// document.addEventListener('DOMContentLoaded', webViewerLoad, true);
+    +PDFJS.webViewerLoad = function (src) {
+    +  if (src) DEFAULT_URL = src;
+    +
+    +  webViewerLoad();
+    +}
+
+On several places the code assumes that a PDF is loaded, which (because of the explicit load) might not be the case. We
+need to check if `pdfDocument` is set before using it.
+
+##### PDFViewerApplication.pagesCount() and PDFLinkService.pagesCount()
+
+         get pagesCount() {
+    -      return this.pdfDocument.numPages;
+    +      return this.pdfDocument ? this.pdfDocument.numPages : 0;
+         },
+
+_The pagesCount method for both `PDFViewerApplication` and `PDFLinkService`. Both need to be patched._
+
+##### PDFViewerApplication.cleanup()
+
+       cleanup: function pdfViewCleanup() {
+         this.pdfViewer.cleanup();
+         this.pdfThumbnailViewer.cleanup();
+    -    this.pdfDocument.cleanup();
+    +    if (this.pdfDocument) {
+    +      this.pdfDocument.cleanup();
+    +    }
+       },
+
+#### overlayManagerRegister
+
+The overlay is registered when the viewer is loaded. The original code will only do this once and give an error on each
+subsequent call. Escpecially with single-page applications (eg an Angular app), the viewer may be loaded multiple times.
+This patch causes pdf.js to unregister an unusued (closed) overlay.
+
+       register: function overlayManagerRegister(name, callerCloseMethod, canForceClose) {
+         return new Promise(function (resolve) {
+           var element, container;
+           if (!name || !(element = document.getElementById(name)) ||
+               !(container = element.parentNode)) {
+             throw new Error('Not enough parameters.');
+           } else if (this.overlays[name]) {
+    -        throw new Error('The overlay is already registered.');
+    +        if (this.active !== name) {
+    +          this.unregister(name);
+    +        } else {
+    +          throw new Error('The overlay is already registered and active.');
+    +        }
+           }
+
+#### webViewerChange trigger on file upload dialog
+
+Whenever a file dialog is used (so with any `<input type="file">` on the page), the file is loaded into the pdf.js
+viewer. We don't want this behaviour, so comment it out.
+
+    -window.addEventListener('change', function webViewerChange(evt) {
+    +/*window.addEventListener('change', function webViewerChange(evt) {
+       var files = evt.target.files;
+       if (!files || files.length === 0) {
+         return;
+    @@ -17627,7 +17647,7 @@
+         setAttribute('hidden', 'true');
+       document.getElementById('download').setAttribute('hidden', 'true');
+       document.getElementById('secondaryDownload').setAttribute('hidden', 'true');
+    -}, true);
+    +}, true);*/
+
+#### handleMouseWheel()
+
+The JavaScript pdf.js file might be loaded while the viewer isn't being displayed. This causes an error on mouse move.
+We need to check if the viewer is initialized, before handling the event.
+
+     function handleMouseWheel(evt) {
+    +  // Ignore mousewheel event if pdfViewer isn't loaded
+    +  if (!PDFViewerApplication.pdfViewer) return;
+
+#### Load code for worker using AJAX
+
+A [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers) can't use code from
+a same-origin domain. The CORS headers don't apply (they do work in some browsers, but not in all).
+
+To get around this, the source code of the worker is fetched using AJAX and presented as blob.
+
+ var WorkerTransport = (function WorkerTransportClosure() {
+   function WorkerTransport(workerInitializedCapability, pdfDataRangeTransport) {
++    /**
++     * Needed because workers cannot load scripts outside of the current origin (as of firefox v45).
++     * This patch does require the worker script to be served with a (Access-Control-Allow-Origin: *) header
++     * @patch
++     */
++    globalScope.cachedJSDfd = null;
++    this.loadWorkerXHR = function(url){
++      if (globalScope.cachedJSDfd) { return globalScope.cachedJSDfd; }
++      globalScope.cachedJSDfd = PDFJS.createPromiseCapability();
++
++      var xmlhttp;
++      xmlhttp = new XMLHttpRequest();
++
++      xmlhttp.onreadystatechange = function(){
++        if (xmlhttp.readyState == 4 && xmlhttp.status == 200){
++          var workerJSBlob = new Blob([xmlhttp.responseText], { type: 'text/javascript' });
++          globalScope.cachedJSDfd.resolve(window.URL.createObjectURL(workerJSBlob));
++        }
++      };
++
++      xmlhttp.open('GET', url, true);
++      xmlhttp.send();
++      return globalScope.cachedJSDfd.promise;
++    }
+
+Instead of simply starting the worker, we need to get the code and than start it.
+
++      this.loadWorkerXHR(workerSrc).then(function(blob) {
++      workerSrc = PDFJS.workerSrc = blob;
++
+       try {
+         // Some versions of FF can't create a worker on localhost, see:
+         // https://bugzilla.mozilla.org/show_bug.cgi?id=683280
+@@ -3589,11 +3618,16 @@
+         return;
+       } catch (e) {
+         info('The worker has been disabled.');
++        this.setupFakeWorker();
+       }
++
++      }.bind(this));
+     }
+
+As the worker is started async, we only start the worker on an error, when the browser doesn't support web workers or
+when it's explicitly set that we don't want to use the web worker api.
+
+     // Either workers are disabled, not supported or have thrown an exception.
+     // Thus, we fallback to a faked worker.
+-    this.setupFakeWorker();
++    if (globalScope.PDFJS.disableWorker || typeof Worker === 'undefined') {
++      this.setupFakeWorker();
++    }
+

--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,28 @@
-cat source/web/l10n.js source/build/pdf.js source/web/compatibility.js source/web/debugger.js source/web/viewer.js > pdf.js
+#!/bin/bash
+
+if [[ $# < 1 ]]; then
+  echo USAGE $0 SOURCE_PATH 1>&2
+  exit 1
+fi
+
+source="$1"
+
+if [[ ! -f "$source/build/pdf.js" ]]; then
+  echo "$source/build/pdf.js" not found 1>&2
+  exit 1
+fi
+
+cat "$source/web/l10n.js" "$source/build/pdf.js" "$source/web/compatibility.js" "$source/web/debugger.js" "$source/web/viewer.js" > pdf.js
 patch pdf.js < pdf.js.patch
 
-cp source/build/pdf.worker.js .
+cp "$source/build/pdf.worker.js" .
 patch pdf.worker.js < pdf.worker.js.patch
 
-uglifycss source/web/viewer.css > viewer.css
+uglifycss "$source/web/viewer.css" > viewer.css
 node grunt/css-prefix.js viewer.css viewer.css pdfjs
 
-sed -r 's/url\((")?images\//url\(\1@pdfjsImagePath\//g' < source/web/viewer.css | uglifycss > viewer.less
+sed -r 's/url\((")?images\//url\(\1@pdfjsImagePath\//g' < "$source/web/viewer.css" | uglifycss > viewer.less
 node grunt/css-prefix.js viewer.less viewer.less pdfjs
 
-cp source/web/cmaps/ source/web/images/ source/web/locale/ . -a
+cp "$source/web/cmaps/" "$source/web/images/" "$source/web/locale/" . -a
 

--- a/pdf.js
+++ b/pdf.js
@@ -27,8 +27,6 @@
     - Remove compatibility code for OldIE.
 */
 
-var globalScope = (typeof window === 'undefined') ? this : window;
-
 /*jshint browser: true, devel: true, es5: true, globalstrict: true */
 'use strict';
 
@@ -1087,6 +1085,7 @@ PDFJS.build = 'c9a7498';
 
 'use strict';
 
+var globalScope = (typeof window === 'undefined') ? this : window;
 var isWorker = (typeof window === 'undefined');
 
 var FONT_IDENTITY_MATRIX = [0.001, 0, 0, 0.001, 0, 0];
@@ -3530,16 +3529,12 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
   return PDFPageProxy;
 })();
 
-
 /**
-
  * For internal use only.
  * @ignore
  */
 var WorkerTransport = (function WorkerTransportClosure() {
   function WorkerTransport(workerInitializedCapability, pdfDataRangeTransport) {
-    var self = this;
-
     /**
      * Needed because workers cannot load scripts outside of the current origin (as of firefox v45).
      * This patch does require the worker script to be served with a (Access-Control-Allow-Origin: *) header
@@ -3586,45 +3581,47 @@ var WorkerTransport = (function WorkerTransportClosure() {
         error('No PDFJS.workerSrc specified');
       }
 
+      this.loadWorkerXHR(workerSrc).then(function(blob) {
+      workerSrc = PDFJS.workerSrc = blob;
+
       try {
         // Some versions of FF can't create a worker on localhost, see:
         // https://bugzilla.mozilla.org/show_bug.cgi?id=683280
-        self.loadWorkerXHR(workerSrc).then(function(blob) {
-          workerSrc = PDFJS.workerSrc = blob;
+        var worker = new Worker(workerSrc);
+        var messageHandler = new MessageHandler('main', worker);
+        this.messageHandler = messageHandler;
 
-          var worker = new Worker(workerSrc);
-          var messageHandler = new MessageHandler('main', worker);
-          self.messageHandler = messageHandler;
-
-          messageHandler.on('test', function transportTest(data) {
-            var supportTypedArray = data && data.supportTypedArray;
-            if (supportTypedArray) {
-              self.worker = worker;
-              if (!data.supportTransfers) {
-                PDFJS.postMessageTransfers = false;
-              }
-              self.setupMessageHandler(messageHandler);
-              workerInitializedCapability.resolve();
-            } else if (globalScope.PDFJS.disableWorker || typeof Worker === 'undefined') {
-              this.setupFakeWorker();
+        messageHandler.on('test', function transportTest(data) {
+          var supportTypedArray = data && data.supportTypedArray;
+          if (supportTypedArray) {
+            this.worker = worker;
+            if (!data.supportTransfers) {
+              PDFJS.postMessageTransfers = false;
             }
-          }.bind(self));
-
-          var testObj = new Uint8Array([PDFJS.postMessageTransfers ? 255 : 0]);
-          // Some versions of Opera throw a DATA_CLONE_ERR on serializing the
-          // typed array. Also, checking if we can use transfers.
-          try {
-            messageHandler.send('test', testObj, [testObj.buffer]);
-          } catch (ex) {
-            info('Cannot use postMessage transfers');
-            testObj[0] = 0;
-            messageHandler.send('test', testObj);
+            this.setupMessageHandler(messageHandler);
+            workerInitializedCapability.resolve();
+          } else {
+            this.setupFakeWorker();
           }
-          return;
-        });
+        }.bind(this));
+
+        var testObj = new Uint8Array([PDFJS.postMessageTransfers ? 255 : 0]);
+        // Some versions of Opera throw a DATA_CLONE_ERR on serializing the
+        // typed array. Also, checking if we can use transfers.
+        try {
+          messageHandler.send('test', testObj, [testObj.buffer]);
+        } catch (ex) {
+          info('Cannot use postMessage transfers');
+          testObj[0] = 0;
+          messageHandler.send('test', testObj);
+        }
+        return;
       } catch (e) {
         info('The worker has been disabled.');
+        this.setupFakeWorker();
       }
+
+      }.bind(this));
     }
     // Either workers are disabled, not supported or have thrown an exception.
     // Thus, we fallback to a faked worker.
@@ -9078,6 +9075,17 @@ PDFJS.SVGGraphics = SVGGraphics;
 
 }).call((typeof window === 'undefined') ? this : window);
 
+if (!PDFJS.workerSrc && typeof document !== 'undefined') {
+  // workerSrc is not set -- using last script url to define default location
+  PDFJS.workerSrc = (function () {
+    'use strict';
+    var scriptTagContainer = document.body ||
+                             document.getElementsByTagName('head')[0];
+    var pdfjsSrc = scriptTagContainer.lastChild.src;
+    return pdfjsSrc && pdfjsSrc.replace(/\.js$/i, '.worker.js');
+  })();
+}
+
 
 /* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
@@ -10305,41 +10313,37 @@ var PDFBug = (function PDFBugClosure() {
 
 'use strict';
 
-function initGlobalScope(callback) {
-  globalScope.DEFAULT_URL = 'compressed.tracemonkey-pldi-09.pdf';
-  globalScope.DEFAULT_SCALE_DELTA = 1.1;
-  globalScope.MIN_SCALE = 0.25;
-  globalScope.MAX_SCALE = 10.0;
-  globalScope.VIEW_HISTORY_MEMORY = 20;
-  globalScope.SCALE_SELECT_CONTAINER_PADDING = 8;
-  globalScope.SCALE_SELECT_PADDING = 22;
-  globalScope.PAGE_NUMBER_LOADING_INDICATOR = 'visiblePageIsLoading';
-  globalScope.DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT = 5000;
+var DEFAULT_URL = 'compressed.tracemonkey-pldi-09.pdf';
+var DEFAULT_SCALE_DELTA = 1.1;
+var MIN_SCALE = 0.25;
+var MAX_SCALE = 10.0;
+var VIEW_HISTORY_MEMORY = 20;
+var SCALE_SELECT_CONTAINER_PADDING = 8;
+var SCALE_SELECT_PADDING = 22;
+var PAGE_NUMBER_LOADING_INDICATOR = 'visiblePageIsLoading';
+var DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT = 5000;
 
-  globalScope.scriptTagContainer = document.body ||
-                           document.getElementsByTagName('head')[0];
-  globalScope.pdfjsSrc = scriptTagContainer.lastChild.src;
+var scriptTagContainer = document.body ||
+                         document.getElementsByTagName('head')[0];
+var pdfjsSrc = scriptTagContainer.lastChild.src;
 
-  if (pdfjsSrc) {
-    PDFJS.imageResourcesPath = pdfjsSrc.replace(/pdf\.js$/i, 'images/');
-    PDFJS.workerSrc = pdfjsSrc.replace(/pdf\.js$/i, 'pdf.worker.js');
-    PDFJS.cMapUrl = pdfjsSrc.replace(/pdf\.js$/i, 'cmaps/');
-  }
-
-  PDFJS.cMapPacked = true;
-
-  globalScope.mozL10n = document.mozL10n || document.webL10n;
-
-
-  globalScope.CSS_UNITS = 96.0 / 72.0;
-  globalScope.DEFAULT_SCALE = 'auto';
-  globalScope.UNKNOWN_SCALE = 0;
-  globalScope.MAX_AUTO_SCALE = 1.25;
-  globalScope.SCROLLBAR_PADDING = 40;
-  globalScope.VERTICAL_PADDING = 5;
-
-  callback();
+if (pdfjsSrc) {
+  PDFJS.imageResourcesPath = pdfjsSrc.replace(/pdf\.js$/i, 'images/');
+  PDFJS.workerSrc = pdfjsSrc.replace(/pdf\.js$/i, 'pdf.worker.js');
+  PDFJS.cMapUrl = pdfjsSrc.replace(/pdf\.js$/i, 'cmaps/');
 }
+
+PDFJS.cMapPacked = true;
+
+var mozL10n = document.mozL10n || document.webL10n;
+
+
+var CSS_UNITS = 96.0 / 72.0;
+var DEFAULT_SCALE = 'auto';
+var UNKNOWN_SCALE = 0;
+var MAX_AUTO_SCALE = 1.25;
+var SCROLLBAR_PADDING = 40;
+var VERTICAL_PADDING = 5;
 
 // optimised CSS custom property getter/setter
 var CustomStyle = (function CustomStyleClosure() {
@@ -17507,12 +17511,10 @@ function webViewerInitialized() {
 
 // document.addEventListener('DOMContentLoaded', webViewerLoad, true);
 PDFJS.webViewerLoad = function (src) {
-  initGlobalScope(function () {
-    if (src) DEFAULT_URL = src;
+  if (src) DEFAULT_URL = src;
 
-    webViewerLoad();
-  });
-}
+  webViewerLoad();
+}}
 
 document.addEventListener('pagerendered', function (e) {
   var pageNumber = e.detail.pageNumber;

--- a/pdf.js
+++ b/pdf.js
@@ -17514,7 +17514,7 @@ PDFJS.webViewerLoad = function (src) {
   if (src) DEFAULT_URL = src;
 
   webViewerLoad();
-}}
+};
 
 document.addEventListener('pagerendered', function (e) {
   var pageNumber = e.detail.pageNumber;

--- a/pdf.js.patch
+++ b/pdf.js.patch
@@ -1,5 +1,5 @@
 --- pdf.orig.js	2016-07-20 16:12:49.867043350 +0200
-+++ pdf.js	2016-07-20 18:22:07.715047421 +0200
++++ pdf.js	2016-07-21 00:20:32.536984707 +0200
 @@ -826,7 +826,9 @@
    function getL10nData(key, args, fallback) {
      var data = gL10nData[key];
@@ -11,75 +11,91 @@
        if (!fallback) {
          return null;
        }
-@@ -1084,7 +1086,6 @@
- 'use strict';
+@@ -3544,12 +3546,54 @@
+     this.pagePromises = [];
+     this.downloadInfoCapability = createPromiseCapability();
  
- var globalScope = (typeof window === 'undefined') ? this : window;
--
- var isWorker = (typeof window === 'undefined');
- 
- var FONT_IDENTITY_MATRIX = [0.001, 0, 0, 0.001, 0, 0];
-@@ -3534,6 +3535,31 @@
-  */
- var WorkerTransport = (function WorkerTransportClosure() {
-   function WorkerTransport(workerInitializedCapability, pdfDataRangeTransport) {
 +    /**
 +     * Needed because workers cannot load scripts outside of the current origin (as of firefox v45).
 +     * This patch does require the worker script to be served with a (Access-Control-Allow-Origin: *) header
 +     * @patch
 +     */
-+    globalScope.cachedJSDfd = null;
-+    this.loadWorkerXHR = function(url){
-+      if (globalScope.cachedJSDfd) { return globalScope.cachedJSDfd; }
-+      globalScope.cachedJSDfd = PDFJS.createPromiseCapability();
++    var loadWorkerXHR = function(){
++      var url = PDFJS.workerSrc;
++      var jsdfd = PDFJS.createPromiseCapability();
++
++      if (url.match(/^blob:/) || typeof URL.createObjectURL === 'undefined') {
++        jsdfd.reject(); // Failed loading using blob
++      }
 +
 +      var xmlhttp;
 +      xmlhttp = new XMLHttpRequest();
 +
 +      xmlhttp.onreadystatechange = function(){
-+        if (xmlhttp.readyState == 4 && xmlhttp.status == 200){
++        if (xmlhttp.readyState != 4) return;
++
++        if (xmlhttp.status == 200) {
++          info('Loaded worker source through XHR.');
 +          var workerJSBlob = new Blob([xmlhttp.responseText], { type: 'text/javascript' });
-+          globalScope.cachedJSDfd.resolve(window.URL.createObjectURL(workerJSBlob));
++          jsdfd.resolve(window.URL.createObjectURL(workerJSBlob));
++        } else {
++          jsdfd.reject();
 +        }
 +      };
 +
 +      xmlhttp.open('GET', url, true);
 +      xmlhttp.send();
-+      return globalScope.cachedJSDfd.promise;
++      return jsdfd.promise;
 +    }
 +
-     this.pdfDataRangeTransport = pdfDataRangeTransport;
-     this.workerInitializedCapability = workerInitializedCapability;
-     this.commonObjs = new PDFObjects();
-@@ -3555,6 +3581,9 @@
-         error('No PDFJS.workerSrc specified');
-       }
- 
-+      this.loadWorkerXHR(workerSrc).then(function(blob) {
-+      workerSrc = PDFJS.workerSrc = blob;
++    var workerError = function() {
++      loadWorkerXHR().then(function(blob) {
++        PDFJS.workerSrc = blob;
++        loadWorker();
++      }, function() {
++        this.setupFakeWorker();
++      }.bind(this));
++    }.bind(this);
 +
-       try {
+     // If worker support isn't disabled explicit and the browser has worker
+     // support, create a new web worker and test if it/the browser fullfills
+     // all requirements to run parts of pdf.js in a web worker.
+     // Right now, the requirement is, that an Uint8Array is still an Uint8Array
+     // as it arrives on the worker. Chrome added this with version 15.
+-    if (!globalScope.PDFJS.disableWorker && typeof Worker !== 'undefined') {
++    var loadWorker = function() {
+       var workerSrc = PDFJS.workerSrc;
+       if (!workerSrc) {
+         error('No PDFJS.workerSrc specified');
+@@ -3559,6 +3603,8 @@
          // Some versions of FF can't create a worker on localhost, see:
          // https://bugzilla.mozilla.org/show_bug.cgi?id=683280
-@@ -3589,11 +3618,16 @@
+         var worker = new Worker(workerSrc);
++        worker.onerror = workerError;
++
+         var messageHandler = new MessageHandler('main', worker);
+         this.messageHandler = messageHandler;
+ 
+@@ -3589,11 +3635,16 @@
          return;
        } catch (e) {
          info('The worker has been disabled.');
-+        this.setupFakeWorker();
++        workerError();
        }
-+
-+      }.bind(this));
-     }
+-    }
++    }.bind(this);
      // Either workers are disabled, not supported or have thrown an exception.
      // Thus, we fallback to a faked worker.
 -    this.setupFakeWorker();
-+    if (globalScope.PDFJS.disableWorker || typeof Worker === 'undefined') {
++    if (!globalScope.PDFJS.disableWorker && typeof Worker !== 'undefined') {
++      loadWorker();
++    } else {
 +      this.setupFakeWorker();
 +    }
    }
    WorkerTransport.prototype = {
      destroy: function WorkerTransport_destroy() {
-@@ -10289,10 +10323,17 @@
+@@ -10289,10 +10340,17 @@
  var PAGE_NUMBER_LOADING_INDICATOR = 'visiblePageIsLoading';
  var DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT = 5000;
  
@@ -101,7 +117,7 @@
  
  var mozL10n = document.mozL10n || document.webL10n;
  
-@@ -11740,7 +11781,7 @@
+@@ -11740,7 +11798,7 @@
       * @returns {number}
       */
      get pagesCount() {
@@ -110,7 +126,7 @@
      },
  
      /**
-@@ -13192,7 +13233,11 @@
+@@ -13192,7 +13250,11 @@
            !(container = element.parentNode)) {
          throw new Error('Not enough parameters.');
        } else if (this.overlays[name]) {
@@ -123,7 +139,7 @@
        }
        this.overlays[name] = { element: element,
                                container: container,
-@@ -16485,7 +16530,7 @@
+@@ -16485,7 +16547,7 @@
    },
  
    get pagesCount() {
@@ -132,7 +148,7 @@
    },
  
    set page(val) {
-@@ -17021,7 +17066,9 @@
+@@ -17021,7 +17083,9 @@
    cleanup: function pdfViewCleanup() {
      this.pdfViewer.cleanup();
      this.pdfThumbnailViewer.cleanup();
@@ -143,7 +159,7 @@
    },
  
    forceRendering: function pdfViewForceRendering() {
-@@ -17462,7 +17509,12 @@
+@@ -17462,7 +17526,12 @@
    }
  }
  
@@ -153,11 +169,11 @@
 +  if (src) DEFAULT_URL = src;
 +
 +  webViewerLoad();
-+}}
++};
  
  document.addEventListener('pagerendered', function (e) {
    var pageNumber = e.detail.pageNumber;
-@@ -17585,7 +17637,7 @@
+@@ -17585,7 +17654,7 @@
  });
  
  window.addEventListener('hashchange', function webViewerHashchange(evt) {
@@ -166,7 +182,7 @@
      var hash = document.location.hash.substring(1);
      if (!hash) {
        return;
-@@ -17598,7 +17650,7 @@
+@@ -17598,7 +17667,7 @@
    }
  });
  
@@ -175,7 +191,7 @@
    var files = evt.target.files;
    if (!files || files.length === 0) {
      return;
-@@ -17627,7 +17679,7 @@
+@@ -17627,7 +17696,7 @@
      setAttribute('hidden', 'true');
    document.getElementById('download').setAttribute('hidden', 'true');
    document.getElementById('secondaryDownload').setAttribute('hidden', 'true');
@@ -184,7 +200,7 @@
  
  function selectScaleOption(value) {
    var options = document.getElementById('scaleSelect').options;
-@@ -17738,6 +17790,9 @@
+@@ -17738,6 +17807,9 @@
  }, true);
  
  function handleMouseWheel(evt) {

--- a/pdf.js.patch
+++ b/pdf.js.patch
@@ -1,5 +1,5 @@
---- pdf.orig.js	2016-06-20 13:34:52.370608323 +0200
-+++ pdf.js	2016-06-20 13:35:36.670757885 +0200
+--- pdf.orig.js	2016-07-20 16:12:49.867043350 +0200
++++ pdf.js	2016-07-20 18:22:07.715047421 +0200
 @@ -826,7 +826,9 @@
    function getL10nData(key, args, fallback) {
      var data = gL10nData[key];
@@ -11,7 +11,75 @@
        if (!fallback) {
          return null;
        }
-@@ -10289,10 +10291,17 @@
+@@ -1084,7 +1086,6 @@
+ 'use strict';
+ 
+ var globalScope = (typeof window === 'undefined') ? this : window;
+-
+ var isWorker = (typeof window === 'undefined');
+ 
+ var FONT_IDENTITY_MATRIX = [0.001, 0, 0, 0.001, 0, 0];
+@@ -3534,6 +3535,31 @@
+  */
+ var WorkerTransport = (function WorkerTransportClosure() {
+   function WorkerTransport(workerInitializedCapability, pdfDataRangeTransport) {
++    /**
++     * Needed because workers cannot load scripts outside of the current origin (as of firefox v45).
++     * This patch does require the worker script to be served with a (Access-Control-Allow-Origin: *) header
++     * @patch
++     */
++    globalScope.cachedJSDfd = null;
++    this.loadWorkerXHR = function(url){
++      if (globalScope.cachedJSDfd) { return globalScope.cachedJSDfd; }
++      globalScope.cachedJSDfd = PDFJS.createPromiseCapability();
++
++      var xmlhttp;
++      xmlhttp = new XMLHttpRequest();
++
++      xmlhttp.onreadystatechange = function(){
++        if (xmlhttp.readyState == 4 && xmlhttp.status == 200){
++          var workerJSBlob = new Blob([xmlhttp.responseText], { type: 'text/javascript' });
++          globalScope.cachedJSDfd.resolve(window.URL.createObjectURL(workerJSBlob));
++        }
++      };
++
++      xmlhttp.open('GET', url, true);
++      xmlhttp.send();
++      return globalScope.cachedJSDfd.promise;
++    }
++
+     this.pdfDataRangeTransport = pdfDataRangeTransport;
+     this.workerInitializedCapability = workerInitializedCapability;
+     this.commonObjs = new PDFObjects();
+@@ -3555,6 +3581,9 @@
+         error('No PDFJS.workerSrc specified');
+       }
+ 
++      this.loadWorkerXHR(workerSrc).then(function(blob) {
++      workerSrc = PDFJS.workerSrc = blob;
++
+       try {
+         // Some versions of FF can't create a worker on localhost, see:
+         // https://bugzilla.mozilla.org/show_bug.cgi?id=683280
+@@ -3589,11 +3618,16 @@
+         return;
+       } catch (e) {
+         info('The worker has been disabled.');
++        this.setupFakeWorker();
+       }
++
++      }.bind(this));
+     }
+     // Either workers are disabled, not supported or have thrown an exception.
+     // Thus, we fallback to a faked worker.
+-    this.setupFakeWorker();
++    if (globalScope.PDFJS.disableWorker || typeof Worker === 'undefined') {
++      this.setupFakeWorker();
++    }
+   }
+   WorkerTransport.prototype = {
+     destroy: function WorkerTransport_destroy() {
+@@ -10289,10 +10323,17 @@
  var PAGE_NUMBER_LOADING_INDICATOR = 'visiblePageIsLoading';
  var DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT = 5000;
  
@@ -33,7 +101,7 @@
  
  var mozL10n = document.mozL10n || document.webL10n;
  
-@@ -11740,7 +11749,7 @@
+@@ -11740,7 +11781,7 @@
       * @returns {number}
       */
      get pagesCount() {
@@ -42,7 +110,7 @@
      },
  
      /**
-@@ -13192,7 +13201,11 @@
+@@ -13192,7 +13233,11 @@
            !(container = element.parentNode)) {
          throw new Error('Not enough parameters.');
        } else if (this.overlays[name]) {
@@ -55,7 +123,7 @@
        }
        this.overlays[name] = { element: element,
                                container: container,
-@@ -16485,7 +16498,7 @@
+@@ -16485,7 +16530,7 @@
    },
  
    get pagesCount() {
@@ -64,7 +132,7 @@
    },
  
    set page(val) {
-@@ -17021,7 +17034,9 @@
+@@ -17021,7 +17066,9 @@
    cleanup: function pdfViewCleanup() {
      this.pdfViewer.cleanup();
      this.pdfThumbnailViewer.cleanup();
@@ -75,7 +143,7 @@
    },
  
    forceRendering: function pdfViewForceRendering() {
-@@ -17462,7 +17477,12 @@
+@@ -17462,7 +17509,12 @@
    }
  }
  
@@ -85,11 +153,11 @@
 +  if (src) DEFAULT_URL = src;
 +
 +  webViewerLoad();
-+}
++}}
  
  document.addEventListener('pagerendered', function (e) {
    var pageNumber = e.detail.pageNumber;
-@@ -17585,7 +17605,7 @@
+@@ -17585,7 +17637,7 @@
  });
  
  window.addEventListener('hashchange', function webViewerHashchange(evt) {
@@ -98,7 +166,7 @@
      var hash = document.location.hash.substring(1);
      if (!hash) {
        return;
-@@ -17598,7 +17618,7 @@
+@@ -17598,7 +17650,7 @@
    }
  });
  
@@ -107,7 +175,7 @@
    var files = evt.target.files;
    if (!files || files.length === 0) {
      return;
-@@ -17627,7 +17647,7 @@
+@@ -17627,7 +17679,7 @@
      setAttribute('hidden', 'true');
    document.getElementById('download').setAttribute('hidden', 'true');
    document.getElementById('secondaryDownload').setAttribute('hidden', 'true');
@@ -116,7 +184,7 @@
  
  function selectScaleOption(value) {
    var options = document.getElementById('scaleSelect').options;
-@@ -17738,6 +17758,9 @@
+@@ -17738,6 +17790,9 @@
  }, true);
  
  function handleMouseWheel(evt) {


### PR DESCRIPTION
Added upgrading instructions. This includes an explanation for each of the changes that are made.

Also
* Removed some of the changes that ware not/no longer necessary.
* Changed the code so we're not always loading the pdf.worker.js source through XHR. Instead, first try creating a worker using the pdf.worker.js url. If that fails, use XHR. If that also fails, use the fake worker.