### PR TITLE
Add the css styles in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,9 @@
 {
   "name": "pdf.js-viewer",
-  "main": "pdf.js",
+  "main": [
+    "pdf.js",
+    "viewer.css"
+  ],
   "homepage": "http://github.com/legalthings/pdf.js-viewer",
   "authors": [
     "LegalThings <info@legalthings.net>",


### PR DESCRIPTION
The `main` property in bower.json accepts an array of strings. This allows to load the css using webpack or any other processor.